### PR TITLE
Fix Cartfile.private to include the correct SwiftCheck branch

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "typelift/SwiftCheck" "swift-develop"
+github "typelift/SwiftCheck" ~> 0.8.1


### PR DESCRIPTION
"swift-develop" no longer exists